### PR TITLE
🐞 fix: 修复'退出登录'判断条件

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -35,9 +35,9 @@ SITE_ICP=""
 ## You are advised to fill in 30 - 90
 COUNT_DAYS=60
 
-# Show Links
+# Show Link
 ## Whether to show sites links
-SHOW_LINKS=true
+SHOW_LINK=true
 
 # Password
 ## If you want to protect the data, you can set a password

--- a/app/components/SiteNav.vue
+++ b/app/components/SiteNav.vue
@@ -93,7 +93,7 @@ const navMenu = computed<DropdownOption[]>(() => [
   {
     key: "logout",
     label: t("nav.logout"),
-    show: statusStore.loginStatus,
+    show: statusStore.loginStatus && config.public.hasPassword,
     icon: renderIcon("icon:logout"),
     props: {
       onClick: () => {

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -16,6 +16,7 @@ const siteConfig = {
   showLink: process.env.SHOW_LINK === "true" || true,
   platform: process.env.DEPLOYMENT_PLATFORM || "cloudflare",
   version: pkg.version,
+  hasPassword: !!process.env.SITE_PASSWORD,
 };
 
 export default defineNuxtConfig({

--- a/nuxt.config.ts
+++ b/nuxt.config.ts
@@ -13,7 +13,7 @@ const siteConfig = {
   siteLogo: process.env.SITE_LOGO || "/favicon.ico",
   siteIcp: process.env.SITE_ICP || "",
   countDays: Number(process.env.COUNT_DAYS || 60),
-  showLink: process.env.SHOW_LINK === "true" || true,
+  showLink: process.env.SHOW_LINK === "true",
   platform: process.env.DEPLOYMENT_PLATFORM || "cloudflare",
   version: pkg.version,
   hasPassword: !!process.env.SITE_PASSWORD,


### PR DESCRIPTION
原先的判断逻辑未考虑到用户未配置密码时应不显示导航栏“退出登录”的选项，此时用户点击“退出登录”后，将进入登录界面。通过加入 hasPassword 的 boolean 值判断，在不暴露 .env 设定密码的前提下，实现未登录状态下“退出登录”选项的隐藏。